### PR TITLE
Height snapping for blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ but dynamic-height blocks don't. Dynamic-height blocks can not be resized vertic
 * *resizableBlockHeight* (default: false)
   When set to true and staticGrid is false, vertical resizing is enabled for all blocks. Blocks can be resized to any height.
 
+* *heightSnapIncrement* (default: false)
+  When set to a value, height resizeable blocks will snap to the nearest multiple of this value (in pixels) when resized.
+
 * *staticGrid* (default: true)
   IF set then no resizing or dragging is possible otherwise dragging and resizing is enabled (resizing is dependent on other options) but requires jQuery UI.
 

--- a/src/supergrid.js
+++ b/src/supergrid.js
@@ -2,14 +2,8 @@
     if (typeof define === 'function' && define.amd) {
         define(['jquery', 'lodash'], factory);
     } else if (typeof exports !== 'undefined') {
-        try {
-            jQuery = require('jquery');
-        } catch (e) {
-        }
-        try {
-            _ = require('lodash');
-        } catch (e) {
-        }
+        try { jQuery = require('jquery'); } catch (e) { }
+        try { _ = require('lodash'); } catch (e) { }
         factory(jQuery, _);
     } else {
         factory(jQuery, _);
@@ -54,10 +48,8 @@
             minBlockWidth: 1,
             collapseContainerWidth: 700,
             heightSnapIncrement: false,
-            onChange: function () {
-            },
-            onLoaded: function () {
-            }
+            onChange: function () {},
+            onLoaded: function () {}
         });
 
         this.element = $(selector);

--- a/src/supergrid.js
+++ b/src/supergrid.js
@@ -2,8 +2,14 @@
     if (typeof define === 'function' && define.amd) {
         define(['jquery', 'lodash'], factory);
     } else if (typeof exports !== 'undefined') {
-        try { jQuery = require('jquery'); } catch (e) { }
-        try { _ = require('lodash'); } catch (e) { }
+        try {
+            jQuery = require('jquery');
+        } catch (e) {
+        }
+        try {
+            _ = require('lodash');
+        } catch (e) {
+        }
         factory(jQuery, _);
     } else {
         factory(jQuery, _);
@@ -48,8 +54,10 @@
             minBlockWidth: 1,
             collapseContainerWidth: 700,
             heightSnapIncrement: false,
-            onChange: function () {},
-            onLoaded: function () {}
+            onChange: function () {
+            },
+            onLoaded: function () {
+            }
         });
 
         this.element = $(selector);
@@ -222,11 +230,12 @@
 
     SuperGrid.prototype._updateBlockElement = function (block) {
         block.element.attr({'data-grid-x': block.x, 'data-grid-width': block.width});
-        block.element.attr('data-grid-height', block.height);
         block.element.css({width: '', left: ''});
 
-        if (block.fixedHeight)
+        if (block.fixedHeight) {
+            block.element.attr('data-grid-height', block.height);
             block.element.css('height', block.height + 'px');
+        }
         else
             block.element.css({height: ''});
 

--- a/src/supergrid.js
+++ b/src/supergrid.js
@@ -47,6 +47,7 @@
             dragZIndex: 100,
             minBlockWidth: 1,
             collapseContainerWidth: 700,
+            heightSnapIncrement: false,
             onChange: function () {},
             onLoaded: function () {}
         });
@@ -221,8 +222,14 @@
 
     SuperGrid.prototype._updateBlockElement = function (block) {
         block.element.attr({'data-grid-x': block.x, 'data-grid-width': block.width});
+        block.element.attr('data-grid-height', block.height);
         block.element.css({width: '', left: ''});
-        if (!block.fixedHeight) block.element.css({height: ''});
+
+        if (block.fixedHeight)
+            block.element.css('height', block.height + 'px');
+        else
+            block.element.css({height: ''});
+
     };
 
     SuperGrid.prototype._updateBlockY = function (block, top) {
@@ -263,8 +270,13 @@
         block.x = startX;
         block.width = endX - startX;
 
+        if (this.options.heightSnapIncrement)
+            block.height = Math.ceil(size.height / this.options.heightSnapIncrement) * this.options.heightSnapIncrement;
+        else
+            block.height = size.height;
+
+
         this._updateBlockY(block, position.top);
-        if (block.fixedHeight) block.height = size.height;
 
         return (old.x != block.x || old.y != block.y || old.width != block.width);
     };

--- a/views/index.pug
+++ b/views/index.pug
@@ -15,6 +15,7 @@ html
             #enable-static-grid.button Enable static grid
             #enable-dynamic-grid.button Enable dynamic grid
             #enable-dynamic-height-grid.button Enable dynamic grid with resizable height
+            #enable-dynamic-height-grid-snapping.button Enable dynamic grid with resizable height (snapping)
             #disable-grid.button Disable grid
             #force-layout.button Force layout
             #json-out.button Output JSON
@@ -95,6 +96,9 @@ html
             });
             $('#enable-dynamic-height-grid').click(function () {
                 window.grid = new SuperGrid('#grid-container', {staticGrid: false, resizableBlockWidth: true, resizableBlockHeight: true});
+            });
+            $('#enable-dynamic-height-grid-snapping').click(function () {
+                            window.grid = new SuperGrid('#grid-container', {staticGrid: false, resizableBlockWidth: true, resizableBlockHeight: true, heightSnapIncrement: 50});
             });
             $('#disable-grid').click(function () {
                 window.grid.destroy()


### PR DESCRIPTION
Add the heightSnapIncrement option, allowing you to specify (in pixels) the nearest multiple to snap the block's height to. 