### PR TITLE
Remove the `grid-vertical` class from a block on `removeBlock`

### DIFF
--- a/lib/supergrid.js
+++ b/lib/supergrid.js
@@ -148,7 +148,7 @@
         }
 
         block.element.data('grid-id', null);
-        block.element.removeClass('grid-placed');
+        block.element.removeClass('grid-placed grid-vertical');
     };
 
     SuperGrid.prototype.destroy = function () {


### PR DESCRIPTION
If this is not removed, the `position: static` style remains, and if the grid is the re-initialized, JQueryUI draggable sets the position to `relative`. See: https://github.com/jquery/jquery-ui/blob/master/ui/widgets/draggable.js#L401