### PR TITLE
Jquery's `data` attributes does not update `attr` attributes

### DIFF
--- a/lib/supergrid.js
+++ b/lib/supergrid.js
@@ -20,18 +20,17 @@
     var Block = function (element) {
         this.element = element;
         this.id = -1;
-        this.x = Math.max(Math.min(element.data('grid-x') || 0, 6), 0);
-        this.y = element.data('grid-y') || 0;
-        this.width = Math.max(Math.min(element.data('grid-width') || 1, 6), 1);
+        this.x = Math.max(Math.min(element.attr('data-grid-x') | 0, 6), 0);
+        this.y = element.attr('data-grid-y') | 0;
+        this.width = Math.max(Math.min((element.attr('data-grid-width') || 1) | 0, 6), 1);
         this.height = 0;
         this.fixedHeight = false;
         this.resizableWidth = !!element.data('grid-width-resizable');
         this.resizableHeight = !!element.data('grid-height-resizable');
         this.jsonId = -1;
 
-        var height = element.data('grid-height');
-        if (height) {
-            this.height = height;
+        if (element.attr('data-grid-height')) {
+            this.height = element.attr('data-grid-height') | 0;
             this.fixedHeight = true;
             this.element.css('height', this.height);
         }


### PR DESCRIPTION
Jquery's `data` attributes does not update `attr` attributes, and vice versa. Thus `data` and `attr` cannot be used interchangeably.